### PR TITLE
fix: replace deprecated `url.parse()` with `new URL()`

### DIFF
--- a/src/node/agent.js
+++ b/src/node/agent.js
@@ -2,8 +2,6 @@
  * Module dependencies.
  */
 
-// eslint-disable-next-line node/no-deprecated-api
-const { parse } = require('url');
 const { CookieJar } = require('cookiejar');
 const { CookieAccessInfo } = require('cookiejar');
 const methods = require('methods');
@@ -55,7 +53,7 @@ class Agent extends AgentBase {
   _saveCookies (res) {
     const cookies = res.headers['set-cookie'];
     if (cookies) {
-      const url = parse(res.request?.url || '');
+      const url = new URL(res.request?.url || '');
       this.jar.setCookies(cookies, url.hostname, url.pathname);
     }
   }
@@ -67,7 +65,7 @@ class Agent extends AgentBase {
    * @api private
    */
   _attachCookies (request_) {
-    const url = parse(request_.url);
+    const url = new URL(request_.url);
     const access = new CookieAccessInfo(
       url.hostname,
       url.pathname,

--- a/src/node/http2wrapper.js
+++ b/src/node/http2wrapper.js
@@ -2,8 +2,6 @@ const http2 = require('http2');
 const Stream = require('stream');
 const net = require('net');
 const tls = require('tls');
-// eslint-disable-next-line node/no-deprecated-api
-const { parse } = require('url');
 
 const {
   HTTP2_HEADER_PATH,
@@ -145,7 +143,7 @@ class Request extends Stream {
         case HTTP2_HEADER_HOST:
           key = HTTP2_HEADER_AUTHORITY;
           value = /^http:\/\/|^https:\/\//.test(value)
-            ? parse(value).host
+            ? new URL(value).host
             : value;
           break;
         default:

--- a/test/node/basic-auth.js
+++ b/test/node/basic-auth.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const URL = require('url');
+const { format } = require('url');
 const request = require('../support/client');
 const getSetup = require('../support/setup');
 
@@ -14,11 +14,12 @@ describe('Basic auth', () => {
 
   describe('when credentials are present in url', () => {
     it('should set Authorization', (done) => {
-      const new_url = URL.parse(base);
-      new_url.auth = 'tobi:learnboost';
+      const new_url = new URL(base);
+      new_url.username = 'tobi';
+      new_url.password = 'learnboost';
       new_url.pathname = '/basic-auth';
 
-      request.get(URL.format(new_url)).end((error, res) => {
+      request.get(format(new_url)).end((error, res) => {
         assert.equal(res.status, 200);
         done();
       });

--- a/test/node/basic.js
+++ b/test/node/basic.js
@@ -4,7 +4,6 @@ const assert = require('assert');
 const fs = require('fs');
 const { EventEmitter } = require('events');
 const { StringDecoder } = require('string_decoder');
-const url = require('url');
 const getSetup = require('../support/setup');
 const request = require('../support/client');
 
@@ -30,7 +29,7 @@ describe('[node] request', () => {
 
   describe('with an object', () => {
     it('should format the url', () =>
-      request.get(url.parse(`${base}/login`)).then((res) => {
+      request.get(new URL(`${base}/login`)).then((res) => {
         assert.ok(res.ok);
       }));
   });

--- a/test/node/http2.js
+++ b/test/node/http2.js
@@ -4,7 +4,6 @@ if (!process.env.HTTP2_TEST) {
 }
 
 const assert = require('assert');
-const url = require('url');
 const request = require('../..');
 const getSetup = require('../support/setup');
 
@@ -29,7 +28,7 @@ describe('request.get().http2()', () => {
 
   it('should format the url', () =>
     request
-      .get(url.parse(`${base}/login`))
+      .get(new URL(`${base}/login`))
       .http2()
       .then((res) => {
         assert(res.ok);

--- a/test/node/https.js
+++ b/test/node/https.js
@@ -2,7 +2,6 @@
 
 const assert = require('assert');
 
-const url = require('url');
 const https = require('https');
 const fs = require('fs');
 const express = require('../support/express');
@@ -128,7 +127,7 @@ describe('https', () => {
           assert.ifError(error);
           assert(res.ok);
           assert.strictEqual('Safe and secure!', res.text);
-          agent.get(url.parse(testEndpoint)).end((error, res) => {
+          agent.get(new URL(testEndpoint)).end((error, res) => {
             assert.ifError(error);
             assert(res.ok);
             assert.strictEqual('Safe and secure!', res.text);
@@ -221,7 +220,7 @@ describe('https', () => {
           assert.ifError(error);
           assert(res.ok);
           assert.strictEqual('Safe and secure!', res.text);
-          agent.get(url.parse(testEndpoint)).end((error, res) => {
+          agent.get(new URL(testEndpoint)).end((error, res) => {
             assert.ifError(error);
             assert(res.ok);
             assert.strictEqual('Safe and secure!', res.text);
@@ -235,7 +234,7 @@ describe('https', () => {
           assert.ifError(error);
           assert(res.ok);
           assert.strictEqual('Safe and secure!', res.text);
-          agent.get(url.parse(testEndpoint)).end((error, res) => {
+          agent.get(new URL(testEndpoint)).end((error, res) => {
             assert.ifError(error);
             assert(res.ok);
             assert.strictEqual('Safe and secure!', res.text);

--- a/test/node/redirects.js
+++ b/test/node/redirects.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const URL = require('url');
 const assert = require('assert');
 const getSetup = require('../support/setup');
 const request = require('../support/client');
@@ -112,7 +111,7 @@ describe('request', () => {
 
     it('should follow Location with IP override', () => {
       const redirects = [];
-      const url = URL.parse(base);
+      const url = new URL(base);
       return request
         .get(`http://redir.example.com:${url.port || '80'}${url.pathname}`)
         .connect({
@@ -130,7 +129,7 @@ describe('request', () => {
 
     it('should follow Location with IP:port override', () => {
       const redirects = [];
-      const url = URL.parse(base);
+      const url = new URL(base);
       return request
         .get(`http://redir.example.com:9999${url.pathname}`)
         .connect({

--- a/test/use.js
+++ b/test/use.js
@@ -88,7 +88,7 @@ describe('subclass', () => {
     NewRequest.prototype = Object.create(OriginalRequest.prototype);
     request.Request = NewRequest;
 
-    const request_ = request.agent().del('/');
+    const request_ = request.agent().del('http://test.com/');
     assert(request_ instanceof NewRequest);
     assert(request_ instanceof OriginalRequest);
   });


### PR DESCRIPTION
## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.

Replaces the other occurrences of `url.parse()` with `new URL()`. Continuation of PR #1802.