### PR TITLE
feat(client): add proxy object for `request.agent` for compatibility

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -872,7 +872,14 @@ Request.prototype._end = function () {
   xhr.send(typeof data === 'undefined' ? null : data);
 };
 
-request.agent = () => new Agent();
+// create a Proxy that can instantiate a new Agent without using `new` keyword
+// (for backward compatibility and chaining)
+const proxyAgent = new Proxy(Agent, {
+  apply(target, thisArg, argumentsList) {
+    return new target(...argumentsList);
+  }
+});
+request.agent = proxyAgent;
 
 for (const method of ['GET', 'POST', 'OPTIONS', 'PATCH', 'PUT', 'DELETE']) {
   Agent.prototype[method.toLowerCase()] = function (url, fn) {


### PR DESCRIPTION
In node environments, the code in `node/agent.js` creates a proxy object around `Agent` so that it can be instantiated without using the `new` keyword. The equivalent code for the browser version (in `client.js`) defines `request.agent` as `() => new Agent()`.

In supertest, the `TestAgent` attempts to subclass `Agent` with the call `Object.setPrototypeOf(TestAgent.prototype, Agent.prototype);`. This works in the node environment but not in the browser version, because in the browser version `() => new Agent()` is not an object and has an undefined prototype, leading to the error message `Object prototype may only be an Object or null: undefined`.

Wrap `request.agent` in a proxy object for the client/browser case so that supertest can also use the library in browser contexts without error.

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
